### PR TITLE
Add dev script alias for ng serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "dev": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",


### PR DESCRIPTION
Added "dev": "ng serve" script to package.json as an alias for the start command.
This provides a more standardized development command across projects.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=quantum-nest&projectId=000f8fff04c74e09beac3a783373d10e)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>000f8fff04c74e09beac3a783373d10e</projectId>-->